### PR TITLE
Add security configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ To run the project you need PHP and Composer installed:
 
 ```bash
 composer install
-php bin/console doctrine:database:create --if-not-exists
-php bin/console doctrine:schema:update --force
+./bin/console doctrine:database:create --if-not-exists
+./bin/console doctrine:schema:update --force
 symfony server:start
 ```

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,11 @@
+#!/usr/bin/env php
+<?php
+
+use App\Kernel;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+
+require dirname(__DIR__).'/vendor/autoload.php';
+
+$kernel = new Kernel($_SERVER['APP_ENV'] ?? 'dev', (bool) ($_SERVER['APP_DEBUG'] ?? true));
+$application = new Application($kernel);
+$application->run();

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -1,4 +1,5 @@
 security:
+    enable_authenticator_manager: true
     password_hashers:
         Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface: 'auto'
     providers:

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -13,11 +13,16 @@ class Kernel extends BaseKernel
 
     protected function configureContainer(ContainerConfigurator $container): void
     {
+        $container->import(__DIR__.'/../config/{packages}/*.yaml');
+        $container->import(__DIR__.'/../config/{packages}/'.$this->environment.'/*.yaml');
+
         $container->import(__DIR__.'/../config/services.yaml');
+        $container->import(__DIR__.'/../config/{services}_'.$this->environment.'.yaml');
     }
 
     protected function configureRoutes(RoutingConfigurator $routes): void
     {
+        $routes->import(__DIR__.'/../config/{routes}/'.$this->environment.'/*.yaml');
         $routes->import(__DIR__.'/../config/routes.yaml');
     }
 }


### PR DESCRIPTION
## Summary
- load config packages in Kernel to ensure bundle configs are read
- enable authenticator manager in `security.yaml`

## Testing
- `composer validate --no-interaction` *(fails: command not found)*
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e535d706483299f1b40e8d811102b