### PR TITLE
Enable EasyAdmin login routes

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -20,7 +20,18 @@ security:
             pattern: ^/api
             stateless: true
             jwt: ~
+        admin:
+            lazy: true
+            provider: app_user_provider
+            pattern: ^/
+            form_login:
+                login_path: app_login
+                check_path: app_login
+                default_target_path: /admin
+            logout:
+                path: app_logout
     access_control:
+        - { path: ^/login, roles: PUBLIC_ACCESS }
         - { path: ^/api/login, roles: PUBLIC_ACCESS }
         - { path: ^/api/token/refresh, roles: PUBLIC_ACCESS }
         - { path: ^/api, roles: IS_AUTHENTICATED_FULLY }

--- a/src/Controller/SecurityController.php
+++ b/src/Controller/SecurityController.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
+
+class SecurityController extends AbstractController
+{
+    #[Route('/login', name: 'app_login')]
+    public function login(AuthenticationUtils $authenticationUtils): Response
+    {
+        return $this->render('security/login.html.twig', [
+            'last_username' => $authenticationUtils->getLastUsername(),
+            'error' => $authenticationUtils->getLastAuthenticationError(),
+        ]);
+    }
+
+    #[Route('/logout', name: 'app_logout')]
+    public function logout(): void
+    {
+        // controller can be blank: it will be intercepted by the logout key on your firewall
+    }
+}

--- a/templates/security/login.html.twig
+++ b/templates/security/login.html.twig
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Login</title>
+</head>
+<body>
+    <form action="{{ path('app_login') }}" method="post">
+        {% if error %}
+            <div>{{ error.messageKey|trans(error.messageData, 'security') }}</div>
+        {% endif %}
+        <label for="username">Username:</label>
+        <input type="text" id="username" name="_username" value="{{ last_username }}" required autofocus>
+        <label for="password">Password:</label>
+        <input type="password" id="password" name="_password" required>
+        <button type="submit">Login</button>
+    </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `SecurityController` with login and logout routes
- enable interactive login in `security.yaml`
- provide a minimal login Twig template

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e91d47dac832990cbcfe354799e5d